### PR TITLE
Edge Subscription - change firewall on port 50636 from UDP to TCP

### DIFF
--- a/templates/exchange-old.template
+++ b/templates/exchange-old.template
@@ -2979,7 +2979,7 @@
                         }
                     },
                     {
-                        "IpProtocol": "udp",
+                        "IpProtocol": "tcp",
                         "FromPort": "50636",
                         "ToPort": "50636",
                         "CidrIp": {
@@ -2987,7 +2987,7 @@
                         }
                     },
                     {
-                        "IpProtocol": "udp",
+                        "IpProtocol": "tcp",
                         "FromPort": "50636",
                         "ToPort": "50636",
                         "CidrIp": {

--- a/templates/exchange.template
+++ b/templates/exchange.template
@@ -1765,17 +1765,17 @@ Resources:
       VpcId: !Ref VPCID
       SecurityGroupIngress:
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet1CIDR
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet2CIDR
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet3CIDR


### PR DESCRIPTION
*Issue #, if available:*

Edge subscriptions are failing because we are allowing only UDP but the edge subscription relies on secure LDAP which is TCP. Only UDP packets are allowed by the security group.

*Description of changes:*
See bug here:
https://github.com/aws-quickstart/quickstart-microsoft-exchange/issues/26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
