### PR TITLE
port 50636 - change rule from UDP to TCP

### DIFF
--- a/templates/exchange.template.yaml
+++ b/templates/exchange.template.yaml
@@ -1745,17 +1745,17 @@ Resources:
       VpcId: !Ref VPCID
       SecurityGroupIngress:
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet1CIDR
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet2CIDR
       - Description: Edge Server directory synchronization
-        IpProtocol: udp
+        IpProtocol: tcp
         FromPort: 50636
         ToPort: 50636
         CidrIp: !Ref PrivateSubnet3CIDR


### PR DESCRIPTION
changed udp to tcp for port 50636 (Secure LDAP connection for edge subscriptions)
https://docs.microsoft.com/en-us/Exchange/architecture/edge-transport-servers/edge-subscriptions?view=exchserver-2019

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
